### PR TITLE
[정인호] TypeHandler를 구현, 타입핸들러경로 설정, SportsEquipmentTest.java  커스텀 Enum…

### DIFF
--- a/src/main/java/com/tree/gdhealth/mybatis/typehandler/CodeEnum.java
+++ b/src/main/java/com/tree/gdhealth/mybatis/typehandler/CodeEnum.java
@@ -1,0 +1,19 @@
+package com.tree.gdhealth.mybatis.typehandler;
+
+/**
+ * <p>마이바티스의 타입핸들러에 제네릭타입을 사용하기 위한 커스텀 자바이넘의 구현대상인터페이스</p>
+ * @apiNote String code는 Enum 상수에 대응되는 첫번째 String 필드를 말함 (실제 DB에서 Enum으로 제한된 값과 일치해야 예외가 발생하지 않음
+ * @author 정인호
+ */
+public interface CodeEnum {
+    /**
+     * @return db의 enum문자열을 반환
+     */
+    String getCode();
+
+    /**
+     * @param code db의 enum 문자열 e.g. : "월요일"
+     * @return 커스텀 이넘의 상수 e.g. : MONDAY
+     */
+    CodeEnum fromCode(String code);
+}

--- a/src/main/java/com/tree/gdhealth/mybatis/typehandler/CodeEnumTypeHandler.java
+++ b/src/main/java/com/tree/gdhealth/mybatis/typehandler/CodeEnumTypeHandler.java
@@ -1,0 +1,46 @@
+package com.tree.gdhealth.mybatis.typehandler;
+
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.TypeHandler;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**<p>커스텀 이넘타입을 작성시 중첩정적클래스로 손쉽게 타입핸들러를 구현이 가능한 추상클래스</p>
+ * @apiNote 구현클래스의 위에 @MappedType(클래스.class)를 적어야하며, 마이바티스 설정 파일에 타입핸들러를 추가해야한다.
+ * 내부클래스경로는 외부클래스$내부클래스 로 표현
+ * @author 정인호
+ *
+ */
+public abstract class CodeEnumTypeHandler<E extends CodeEnum> implements TypeHandler<CodeEnum> {
+    private final E customEnum;
+
+    public CodeEnumTypeHandler(E customEnum){
+        this.customEnum = customEnum;
+    }
+
+    @Override
+    public void setParameter(PreparedStatement ps, int i, CodeEnum parameter, JdbcType jdbcType) throws SQLException {
+        ps.setString(i, parameter.getCode());
+    }
+
+    @Override
+    public CodeEnum getResult(ResultSet rs, String columnName) throws SQLException {
+        String code = rs.getString(columnName);
+        return customEnum.fromCode(code);
+    }
+
+    @Override
+    public CodeEnum getResult(ResultSet rs, int columnIndex) throws SQLException {
+        String code = rs.getString(columnIndex);
+        return customEnum.fromCode(code);
+    }
+
+    @Override
+    public CodeEnum getResult(CallableStatement cs, int columnIndex) throws SQLException {
+        String code = cs.getString(columnIndex);
+        return customEnum.fromCode(code);
+    }
+}

--- a/src/main/java/com/tree/gdhealth/sportsequipment/vo/OrderStatus.java
+++ b/src/main/java/com/tree/gdhealth/sportsequipment/vo/OrderStatus.java
@@ -1,26 +1,27 @@
 package com.tree.gdhealth.sportsequipment.vo;
+
+import lombok.Getter;
+
 /**
  * @author 정인호
  */
+@Getter
 public enum OrderStatus {
     WAITING("대기"),
     APPROVED("승인"),
     DENIED("거부");
 
-    private final String status;
-    private OrderStatus(String str) {
-        this.status = str;
-    }
-    public String getStatusText() {
-        return status;
+    private final String code;
+    private OrderStatus(String code) {
+        this.code = code;
     }
 
-    public static OrderStatus fromStatusText(String statusStr) {
+    public static OrderStatus fromCode(String code) {
         for (OrderStatus orderStatus : OrderStatus.values()) {
-            if (orderStatus.status.equals(statusStr)) {
+            if (orderStatus.code.equals(code)) {
                 return orderStatus;
             }
         }
-        throw new IllegalArgumentException( statusStr + "에 해당하는 Constant가 없습니다");
+        throw new IllegalArgumentException( code + "에 해당하는 Constant가 없습니다");
     }
 }

--- a/src/main/java/com/tree/gdhealth/sportsequipment/vo/OrderStatusTypeHandler.java
+++ b/src/main/java/com/tree/gdhealth/sportsequipment/vo/OrderStatusTypeHandler.java
@@ -1,0 +1,41 @@
+package com.tree.gdhealth.sportsequipment.vo;
+
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.MappedTypes;
+import org.apache.ibatis.type.TypeHandler;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * @author 정인호
+ * <p>Java enum <-> mybatis 을 활용하기 위한 타입핸들러 구현체
+ * </p>
+ */
+@MappedTypes(OrderStatus.class)
+public class OrderStatusTypeHandler implements TypeHandler<OrderStatus> {
+    @Override
+    public void setParameter(PreparedStatement ps, int i, OrderStatus parameter, JdbcType jdbcType) throws SQLException {
+        ps.setString(i, parameter.getCode());
+    }
+
+    @Override
+    public OrderStatus getResult(ResultSet rs, String columnName) throws SQLException {
+        String code = rs.getString(columnName);
+        return OrderStatus.fromCode(code);
+    }
+
+    @Override
+    public OrderStatus getResult(ResultSet rs, int columnIndex) throws SQLException {
+        String code = rs.getString(columnIndex);
+        return OrderStatus.fromCode(code);
+    }
+
+    @Override
+    public OrderStatus getResult(CallableStatement cs, int columnIndex) throws SQLException {
+        String code = cs.getString(columnIndex);
+        return OrderStatus.fromCode(code);
+    }
+}

--- a/src/main/java/com/tree/gdhealth/sportsequipment/vo/SportsEquipment.java
+++ b/src/main/java/com/tree/gdhealth/sportsequipment/vo/SportsEquipment.java
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Data
 public class SportsEquipment {
-    private int sportEquipmentNo;
+    private int sportsEquipmentNo;
     private String itemName;
     private int itemPrice;
     private String note;

--- a/src/main/java/com/tree/gdhealth/sportsequipment/vo/SportsEquipmentOrder.java
+++ b/src/main/java/com/tree/gdhealth/sportsequipment/vo/SportsEquipmentOrder.java
@@ -26,11 +26,13 @@ public class SportsEquipmentOrder {
     private LocalDateTime createdate;
     private LocalDateTime updatedate;
 
+    /*
     public void setOrderStatus(String statusStr) {
-        this.orderStatus = OrderStatus.fromStatusText(statusStr);
+        this.orderStatus = OrderStatus.fromCode(statusStr);
     }
 
     public String getOrderStatusText(){
-        return this.orderStatus.getStatusText();
+        return this.orderStatus.getCode();
     }
+     */
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,3 +18,6 @@ spring.servlet.multipart.enabled=true
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=50MB
 spring.servlet.multipart.resolve-lazily=false
+
+# mybatis-config
+mybatis.config-location=classpath:mybatis-config.xml

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration PUBLIC "-//mybatis.org//DTD Config 3.0//EN" "http://mybatis.org/dtd/mybatis-3-config.dtd">
+<configuration>
+    <!-- Your MyBatis configuration settings go here -->
+    <typeHandlers>
+        <typeHandler handler="com.tree.gdhealth.sportsequipment.vo.OrderStatusTypeHandler"/>
+    </typeHandlers>
+    <!-- Type aliases, mappers, etc. -->
+</configuration>
+<!-- author : 정인호 -->

--- a/src/test/java/com/tree/gdhealth/sportsequipment/vo/SportEquipmentMapperTest.java
+++ b/src/test/java/com/tree/gdhealth/sportsequipment/vo/SportEquipmentMapperTest.java
@@ -2,9 +2,16 @@ package com.tree.gdhealth.sportsequipment.vo;
 
 import org.apache.ibatis.annotations.Mapper;
 
+/**
+ * vo 의 db 연동성 유닛테스트를 위한 테스트 매퍼
+ * @author 정인호
+ */
 @Mapper
 public interface SportEquipmentMapperTest {
     int insertSportsEquipment(SportsEquipment sportsEquipment);
-    SportsEquipment findSportEquipmentByNo(Integer sportEquipmentNo);
+    SportsEquipment findSportsEquipmentByNo(int sportEquipmentNo);
+
+    int insertSportsEquipmentOrder(SportsEquipmentOrder sportsEquipmentOrder);
+    SportsEquipmentOrder findSportsEquipmentOrderByNo(int sportEquipmentOrderNo);
 
 }

--- a/src/test/java/com/tree/gdhealth/sportsequipment/vo/SportEquipmentMapperTest.xml
+++ b/src/test/java/com/tree/gdhealth/sportsequipment/vo/SportEquipmentMapperTest.xml
@@ -1,15 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- author 정인호-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.tree.gdhealth.sportsequipment.vo.SportEquipmentMapperTest">
 
-    <insert id="insertSportsEquipment" parameterType="com.tree.gdhealth.sportsequipment.vo.SportsEquipment" useGeneratedKeys="true" keyProperty="sportEquipmentNo">
+    <insert id="insertSportsEquipment" parameterType="com.tree.gdhealth.sportsequipment.vo.SportsEquipment" useGeneratedKeys="true" keyProperty="sportsEquipmentNo">
         INSERT INTO sports_equipment
             (item_name, item_price, note)
         VALUES
             (#{itemName},#{itemPrice},#{note})
     </insert>
+    <insert id="insertSportsEquipmentOrder" parameterType="com.tree.gdhealth.sportsequipment.vo.SportsEquipmentOrder" useGeneratedKeys="true" keyColumn="order_no" keyProperty="orderNo">
+        INSERT INTO sports_equipment_order
+            (employee_orderer, branch_no, sports_equipment_no, quantity, total_price, employee_approver, order_status)
+        VALUES
+            (#{employeeOrderer},#{branchNo},#{sportsEquipmentNo},#{quantity},#{totalPrice},#{employeeApprover},#{orderStatus})
+    </insert>
 
-    <select id="findSportEquipmentByNo" parameterType="int" resultType="com.tree.gdhealth.sportsequipment.vo.SportsEquipment">
+    <select id="findSportsEquipmentByNo" parameterType="int" resultType="com.tree.gdhealth.sportsequipment.vo.SportsEquipment">
         SELECT sports_equipment_no sportEquipmentNo,
                item_name itemName,
                item_price itemPrice,
@@ -17,5 +24,18 @@
                createdate,
                updatedate
         FROM sports_equipment
+    </select>
+    <select id="findSportsEquipmentOrderByNo" parameterType="int" resultType="com.tree.gdhealth.sportsequipment.vo.SportsEquipmentOrder">
+        SELECT order_no orderNo,
+               employee_orderer employeeOrderer,
+               branch_no branchNo,
+               sports_equipment_no sportsEquipmentNo,
+               quantity,
+               total_price totalPrice,
+               createdate,
+               updatedate,
+               employee_approver employeeApprover,
+               order_status orderStatus
+        FROM sports_equipment_order
     </select>
 </mapper>

--- a/src/test/java/com/tree/gdhealth/sportsequipment/vo/SportsEquipmentTest.java
+++ b/src/test/java/com/tree/gdhealth/sportsequipment/vo/SportsEquipmentTest.java
@@ -8,7 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-/**
+/**<p>Vo와 마이바티스간의 타입 안정성 확인을 위한 테스트</p>
  * @author 정인호
  */
 @Slf4j
@@ -19,20 +19,51 @@ class SportsEquipmentTest {
 
     @Transactional
     @Test
-    void SportEquipmentVo가_DB에_입력되고_조회된다(){
+    void SportsEquipmentVo가_DB에_입력되고_조회된다(){
         //given
         SportsEquipment inVo = SportsEquipment.builder()
                 .itemPrice(500).itemName("testName").note("testNote").build();
-        SportsEquipment outVo = null;
+        SportsEquipment outVo;
 
         //when
         mapper.insertSportsEquipment(inVo);
-        outVo = mapper.findSportEquipmentByNo(inVo.getSportEquipmentNo());
+        outVo = mapper.findSportsEquipmentByNo(inVo.getSportsEquipmentNo());
 
         //then
         log.debug(outVo.toString());
-        assertEquals(outVo.getSportEquipmentNo(), inVo.getSportEquipmentNo());
+        assertEquals(outVo.getSportsEquipmentNo(), inVo.getSportsEquipmentNo());
 
+    }
+
+    /**
+     * 시드 데이터로 테스트를 수행하므로 //given 의 해당 데이터가 변경되면 테스트가 실패할 우려가 있습니다.
+     */
+    @Transactional
+    @Test
+    void SportsEquipmentOrderVo가_DB에_입력되고_조회된다(){
+        //given
+        SportsEquipmentOrder insertVo = SportsEquipmentOrder.builder()
+                .sportsEquipmentNo(1)
+                .employeeOrderer(2)
+                .branchNo(2)
+                .quantity(1)
+                .totalPrice(1240000)
+                .employeeApprover(1)
+                .orderStatus(OrderStatus.WAITING).build();
+
+        SportsEquipmentOrder selectVo;
+
+        //when
+        int affectedRows = mapper.insertSportsEquipmentOrder(insertVo);
+        selectVo = mapper.findSportsEquipmentOrderByNo(insertVo.getOrderNo());
+        insertVo.setCreatedate(selectVo.getCreatedate());
+        insertVo.setUpdatedate(selectVo.getUpdatedate());
+
+        //then
+        log.debug(selectVo.toString());
+        assertEquals(1, affectedRows);
+        assertEquals(insertVo.getOrderNo(), selectVo.getOrderNo());
+        assertEquals(selectVo, insertVo);
     }
 
 }

--- a/개발노트[정인호].md
+++ b/개발노트[정인호].md
@@ -1,21 +1,28 @@
 ## 개발노트[정인호]
 
-``
+#####
 -
-`231223`  
+
+##### 231223
+-  커스텀 Enum 타입 필드를 가지는 Vo객체를 마이바티스의 dto로 사용될 수 있도록 TypeHandler를 구현하여 적용함
+- 마이바티스의 타입핸들러 설정을 담을 [mybatis-config.xml] 을 작성했고 [application.properties]에 경로 설정을 추가함
+- [SportsEquipmentOrder.java]의 커스텀 Enum 타입 필드 OrderStatus가 마이바티스의 연동에 문제가 없는지 확인하기 위해 [SportsEquipmentTest.java] 에 관련 테스트를 추가했음 테스트 성공
+- //TODO 매퍼 xml 오타방지를 위해 resultMap 도입을 고려
+
+##### 231223 
 - 빌드툴 메이븐이 src/main/java 경로 아래의 xml을 무시하는 경우가 있어서 pom.xml에 <build> 하위에 Resources 추가하였음 (일반적으로 클래스패스인 resources/mapper/를 프로퍼티설정에 mapper xml 위치로 지정하는 것이 권장되나 팀원들이 매퍼인터페이스와 xml파일을 동일경로에 위치하는 것에 익숙하여 설정을 추가했음) 또한 관련 테스트 작성시 src/test/java 패키지에서도 xml copy 무시 문제가 발생되었고 설정을 추가하여 해결하였음
 - 어제 생성한 Vo SportsEquipment를 test 패키지에서 생성한 매퍼를 가지고 테스트코드를 작성하여 DB insert, select가 정상작동하는지 단위테스트를 시행했으며 테스트 중에서 필드명 오타를 발견하여 수정하였으며 테스트 완료했음
 - primitive 타입의 초기화시 생기는 기본값 때문에 (int는 0가 되기 때문)에 도메인로직에서 null 체크를 위해 SportsEquipment 정수 필드를 Integer로 했지만 만든 Vo가 공용으로 사용되고, Wrapper 클래스 간의 비교연산시 ==과 .equal를 구분해서 사용해야하기 때문에 팀원들이 불편해 할 수 있기 때문에 어제 생성한 vo클래스의 멤버변수를 int타입으로 변경함
 - DB서버의 mariaDB 버전이 10.5인데 최초 DDL로 데이터베이스 초기화시 10.4버전의 DDL Script로 초기화했었다. 그래서 사용중인 IDE에서 데이터 베이스 스키마와 RDBMS의 버전불일치 경고가 발생했다. 서버로 직접 접속하여 DB버전을 업그레이드했다.
 ![마리아디비 DB 버전 업그레이드](documentResources/마리아디비 DB 버전 업그레이드.png)
 
-`231222`
+##### 231222
 - 어제 없던 팀원들에게 진행상황과 프로퍼티 설정을 설명함
 - 게시판 컨트롤러를 작성하던 팀원이 시드데이터와 로그인한 계정 오브젝트가 없어 접근제어 구현에 어려움을 겪었음. 임시 세션 로그인 기능을 구현하도록 도와줌
 - 지점관리페이지의 외부 템플릿을 풋터,해더, 사이드바 등으로 구분하여 페이지 청사진을 만듦
 - Branch, 및 SportEquipment에 대한 vo를 작성
 
-`231221`
+##### 231221
 - light sail DB 서버를 구축하고 원격접속을 허용함
   - mariadb 10.5 install
   - 데이터베이스 DDL 초기화


### PR DESCRIPTION
##### 231223
-  커스텀 Enum 타입 필드를 가지는 Vo객체를 마이바티스의 dto로 사용될 수 있도록 TypeHandler를 구현하여 적용함
- 마이바티스의 타입핸들러 설정을 담을 [mybatis-config.xml] 을 작성했고 [application.properties]에 경로 설정을 추가함
- [SportsEquipmentOrder.java]의 커스텀 Enum 타입 필드 OrderStatus가 마이바티스의 연동에 문제가 없는지 확인하기 위해 [SportsEquipmentTest.java] 에 관련 테스트를 추가했음 테스트 성공
- //TODO 매퍼 xml 오타방지를 위해 resultMap 도입을 고려


close #17 